### PR TITLE
Changed install rules for header files. 

### DIFF
--- a/designator_integration_cpp/CMakeLists.txt
+++ b/designator_integration_cpp/CMakeLists.txt
@@ -35,8 +35,8 @@ install(TARGETS designator_integration
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(DIRECTORY include/designators/
+  DESTINATION include/designators/
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
 )


### PR DESCRIPTION
Necessary because sub-directory of include-directory was renamed. Addresses https://github.com/code-iai/designator_integration/issues/5